### PR TITLE
Allows delimiting of section key values

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ import (
 
 // Read and modify a configuration file
 func Example() {
+    // set a custom delimiter to be used for key/value seperation
+    configparser.Delimiter = "="
+    
     config, err := configparser.Read("/etc/config.ini")
     if err != nil {
         log.Fatal(err)

--- a/configparser.go
+++ b/configparser.go
@@ -27,6 +27,9 @@ import (
 	"sync"
 )
 
+// Delimiter is the delimiter to be used between section key and values.
+var Delimiter = "="
+
 // Configuration represents a configuration file with its sections and options.
 type Configuration struct {
 	filePath        string                // configuration file
@@ -35,7 +38,7 @@ type Configuration struct {
 	mutex           sync.RWMutex
 }
 
-// A Section in a configuration
+// A Section in a configuration.
 type Section struct {
 	fqn            string
 	options        map[string]string
@@ -372,7 +375,7 @@ func (s *Section) String() string {
 	for _, opt := range s.orderedOptions {
 		value := s.options[opt]
 		if value != "" {
-			parts = append(parts, opt, "=", value, "\n")
+			parts = append(parts, opt, Delimiter, value, "\n")
 		} else {
 			parts = append(parts, opt, "\n")
 		}

--- a/configparser_test.go
+++ b/configparser_test.go
@@ -449,6 +449,25 @@ func TestSaveNewConfigFile(t *testing.T) {
 	}
 }
 
+func TestSectionString(t *testing.T) {
+	Delimiter = " = "
+	s, err := getConfig().Section(SectionName2)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expected := `[MONGODB]
+datadir = /var/lib/mongodb
+smallfiles = true
+`
+	str := s.String()
+	t.Log(expected)
+	t.Log(str)
+	if str != expected {
+		t.Error("section string doesn't match expected string")
+	}
+}
+
 func TestSHA(t *testing.T) {
 	out, err := exec.Command("shasum", ConfigNewFilePath).Output()
 	if err != nil {


### PR DESCRIPTION
Added functionality to allow customization of the delimiter when sections are converted to strings.

This was to allow for compatibility when modifying the AWS credentials file.

Basically we needed key = value as opposed to key=value.